### PR TITLE
fix: bootstrap ex-skill cli workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+.DS_Store
+.coverage
+.pytest_cache/
+.venv/
+
+decrypted/
+messages.txt
+*.sqlite
+
+exes/*
+!exes/example_liuzhimin/
+!exes/example_liuzhimin/**

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,106 @@
+# 安装说明
+
+## 环境要求
+
+- Python 3.9+
+- macOS 或 Windows（自动读取微信/iMessage 时）
+- 微信桌面端保持登录，或 macOS 自带 `~/Library/Messages/chat.db`
+
+## 1. 克隆仓库
+
+```bash
+git clone https://github.com/titanwings/ex-skill
+cd ex-skill
+```
+
+## 2. 创建虚拟环境并安装依赖
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Windows PowerShell:
+
+```powershell
+py -3 -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+```
+
+## 3. 运行自检
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+通过后说明核心 CLI 链路可用：
+
+- `tools/skill_writer.py` 创建 / 更新 / 列表
+- `tools/version_manager.py` 版本回滚
+- `tools/wechat_parser.py --txt` 文本导入
+
+## 4. 快速 smoke test
+
+```bash
+tmpdir="$(mktemp -d)"
+cat > "$tmpdir/meta.json" <<'EOF'
+{"name":"Alice","profile":{"gender":"女","rel_stage":"分手"}}
+EOF
+cat > "$tmpdir/persona.md" <<'EOF'
+## Layer 0
+- 嘴硬心软
+EOF
+python3 tools/skill_writer.py --action create --meta "$tmpdir/meta.json" --persona "$tmpdir/persona.md" --base-dir "$tmpdir/exes"
+python3 tools/skill_writer.py --action list --base-dir "$tmpdir/exes"
+```
+
+如果看到 `触发词：/alice`，说明最基本的生成链路已经跑通。
+
+## 5. 微信 / iMessage 读取说明
+
+### 微信
+
+```bash
+python3 tools/wechat_decryptor.py --find-key-only
+python3 tools/wechat_decryptor.py --db-dir "<微信消息目录>" --output ./decrypted
+python3 tools/wechat_parser.py --db-dir ./decrypted --target "TA 的微信名" --output messages.txt
+```
+
+注意：
+
+- Windows 读取内存时可能需要管理员权限
+- macOS 需要给终端 Full Disk Access；iMessage 读取同样需要
+- 自动解密依赖微信客户端正在登录状态
+
+### iMessage
+
+```bash
+python3 tools/wechat_parser.py --imessage --db ~/Library/Messages/chat.db --target "+1xxxxxxxxxx" --output messages.txt
+```
+
+## 6. 常见问题
+
+### `create` 提示需要 `--slug` 或 `--name`
+
+更新到当前版本后，`--meta` 内已有 `name` 时可以直接创建；如果还报错，请确认 `meta.json` 至少包含：
+
+```json
+{"name":"Alice"}
+```
+
+### `No module named Crypto`
+
+说明依赖未安装完整，重新执行：
+
+```bash
+pip install -r requirements.txt
+```
+
+### 提取不到微信密钥
+
+- 先确认微信桌面端不是锁屏状态
+- Windows 尝试管理员权限
+- macOS 开启终端 Full Disk Access
+- 仍失败时，先用 README 中推荐的第三方导出工具导出文本，再走 `--txt` 链路

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ pip3 install -r requirements.txt
 
 > 微信自动采集支持 Windows 和 macOS，桌面端微信保持登录即可；iMessage 需要 macOS。详见 [INSTALL.md](INSTALL.md)
 
+### 快速自检
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+跑通后再开始真实导入，至少能先确认 `create/update/list/rollback` 和文本导入链路是正常的。
+
 ---
 
 ## 使用

--- a/README_EN.md
+++ b/README_EN.md
@@ -74,6 +74,14 @@ pip3 install -r requirements.txt
 
 > WeChat auto-extraction supports Windows and macOS — just keep the desktop client logged in. iMessage requires macOS. See [INSTALL.md](INSTALL.md) for details.
 
+### Quick self-check
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+Run this before importing real chat data so you know the core `create/update/list/rollback` and text-import flow is working.
+
 ---
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pypinyin>=0.54,<1.0
+psutil>=5.9,<8.0
+pycryptodome>=3.20,<4.0
+pymem>=1.14,<2.0; sys_platform == "win32"

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1,0 +1,177 @@
+import json
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYTHON = sys.executable
+
+
+class CliToolTests(unittest.TestCase):
+    def load_skill_writer_module(self):
+        spec = importlib.util.spec_from_file_location(
+            "skill_writer_module",
+            REPO_ROOT / "tools" / "skill_writer.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    def run_cli(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [PYTHON, *args],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_create_uses_name_from_meta_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            meta_path = tmpdir / "meta.json"
+            persona_path = tmpdir / "persona.md"
+            base_dir = tmpdir / "exes"
+
+            meta_path.write_text(
+                json.dumps(
+                    {
+                        "name": "Alice",
+                        "profile": {
+                            "gender": "女",
+                            "rel_stage": "分手",
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            persona_path.write_text("## Layer 0\n- 嘴硬心软\n", encoding="utf-8")
+
+            result = self.run_cli(
+                "tools/skill_writer.py",
+                "--action",
+                "create",
+                "--meta",
+                str(meta_path),
+                "--persona",
+                str(persona_path),
+                "--base-dir",
+                str(base_dir),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("触发词：/alice", result.stdout)
+            self.assertTrue((base_dir / "alice" / "SKILL.md").exists())
+
+    def test_update_and_rollback_workflow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            base_dir = tmpdir / "exes"
+            persona_path = tmpdir / "persona.md"
+            patch_path = tmpdir / "patch.md"
+
+            persona_path.write_text("## Layer 0\n- 外冷内热\n", encoding="utf-8")
+            patch_path.write_text("## Layer 2\n- 常说晚点回\n", encoding="utf-8")
+
+            create = self.run_cli(
+                "tools/skill_writer.py",
+                "--action",
+                "create",
+                "--name",
+                "alice",
+                "--persona",
+                str(persona_path),
+                "--base-dir",
+                str(base_dir),
+            )
+            self.assertEqual(create.returncode, 0, create.stderr)
+
+            update = self.run_cli(
+                "tools/skill_writer.py",
+                "--action",
+                "update",
+                "--slug",
+                "alice",
+                "--persona-patch",
+                str(patch_path),
+                "--base-dir",
+                str(base_dir),
+            )
+            self.assertEqual(update.returncode, 0, update.stderr)
+
+            list_versions = self.run_cli(
+                "tools/version_manager.py",
+                "--action",
+                "list",
+                "--slug",
+                "alice",
+                "--base-dir",
+                str(base_dir),
+            )
+            self.assertEqual(list_versions.returncode, 0, list_versions.stderr)
+            self.assertIn("v1", list_versions.stdout)
+
+            rollback = self.run_cli(
+                "tools/version_manager.py",
+                "--action",
+                "rollback",
+                "--slug",
+                "alice",
+                "--version",
+                "v1",
+                "--base-dir",
+                str(base_dir),
+            )
+            self.assertEqual(rollback.returncode, 0, rollback.stderr)
+
+            persona_content = (base_dir / "alice" / "persona.md").read_text(encoding="utf-8")
+            self.assertNotIn("常说晚点回", persona_content)
+
+    def test_parse_text_export_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            export_path = tmpdir / "chat.txt"
+            export_path.write_text(
+                "\n".join(
+                    [
+                        "2024-01-01 10:00 Alice：早安",
+                        "2024-01-01 10:01 我：早",
+                        "2024-01-01 10:02 Alice：记得吃饭",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_cli(
+                "tools/wechat_parser.py",
+                "--txt",
+                str(export_path),
+                "--target",
+                "Alice",
+                "--json",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            json_start = result.stdout.find("[")
+            self.assertNotEqual(json_start, -1, result.stdout)
+            payload = json.loads(result.stdout[json_start:])
+            self.assertEqual(len(payload), 3)
+            self.assertEqual(payload[0]["sender"], "them")
+
+    def test_slugify_normalizes_pypinyin_output_to_lowercase(self) -> None:
+        fake_module = types.SimpleNamespace(lazy_pinyin=lambda value: ["Alice", "Li"])
+
+        with mock.patch.dict(sys.modules, {"pypinyin": fake_module}):
+            module = self.load_skill_writer_module()
+            self.assertEqual(module.slugify("Alice Li"), "alice_li")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/skill_writer.py
+++ b/tools/skill_writer.py
@@ -78,6 +78,7 @@ def slugify(name: str) -> str:
 
     import re
     slug = re.sub(r"_+", "_", slug).strip("_")
+    slug = slug.lower()
     return slug if slug else "ex"
 
 
@@ -289,6 +290,12 @@ def main() -> None:
     args = parser.parse_args()
     base_dir = Path(args.base_dir).expanduser()
 
+    meta: dict = {}
+    if args.meta:
+        meta = json.loads(Path(args.meta).read_text(encoding="utf-8"))
+    if args.name:
+        meta["name"] = args.name
+
     if args.action == "list":
         exes = list_exes(base_dir)
         if not exes:
@@ -302,15 +309,9 @@ def main() -> None:
                 print()
 
     elif args.action == "create":
-        if not args.slug and not args.name:
+        if not args.slug and not meta.get("name"):
             print("错误：create 操作需要 --slug 或 --name", file=sys.stderr)
             sys.exit(1)
-
-        meta: dict = {}
-        if args.meta:
-            meta = json.loads(Path(args.meta).read_text(encoding="utf-8"))
-        if args.name:
-            meta["name"] = args.name
 
         slug = args.slug or slugify(meta.get("name", "ex"))
 


### PR DESCRIPTION
## Summary
- fix `skill_writer.py` create flow so `--meta` with a name works without requiring `--slug` or `--name`
- normalize generated slugs to lowercase for consistent behavior with and without `pypinyin`
- add install docs, dependency file, gitignore rules, and CLI smoke tests

## Verification
- `python3 -m unittest discover -s tests -v`
- manual smoke test for `python tools/skill_writer.py --action create --meta ...` inside a local `.venv`
